### PR TITLE
Test Travis Container Infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,12 @@ language: node_js
 sudo: false
 node_js:
 - '0.11'
-before_script:
-  - echo 'Africa/Johannesburg' | tee /etc/timezone
-  - dpkg-reconfigure --frontend noninteractive tzdata
-before_install: npm install -g grunt-cli
+# before_script:
+#   - echo 'Africa/Johannesburg' | sudo tee /etc/timezone
+#   - sudo dpkg-reconfigure --frontend noninteractive tzdata
+before_install:
+  export TZ=Africa/Johannesburg
+  npm install -g grunt-cli
 # env:
 #   global:
 #     - secure: ...

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ node_js:
 #   - echo 'Africa/Johannesburg' | sudo tee /etc/timezone
 #   - sudo dpkg-reconfigure --frontend noninteractive tzdata
 before_install:
-  export TZ=Africa/Johannesburg
+  # export TZ=Africa/Johannesburg
   npm install -g grunt-cli
 # env:
 #   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ node_js:
 #   - echo 'Africa/Johannesburg' | sudo tee /etc/timezone
 #   - sudo dpkg-reconfigure --frontend noninteractive tzdata
 before_install:
-  # export TZ=Africa/Johannesburg
-  npm install -g grunt-cli
+  - export TZ=Africa/Johannesburg
+  - npm install -g grunt-cli
 # env:
 #   global:
 #     - secure: ...

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,14 +2,8 @@ language: node_js
 sudo: false
 node_js:
 - '0.11'
-# before_script:
-#   - echo 'Africa/Johannesburg' | sudo tee /etc/timezone
-#   - sudo dpkg-reconfigure --frontend noninteractive tzdata
 before_install:
   - export TZ=Africa/Johannesburg
   - npm install -g grunt-cli
-# env:
-#   global:
-#     - secure: ...
 after_success:
   - grunt


### PR DESCRIPTION
Needing to remove any calls that require sudo as the container infrastructure can only be used when sudo is not required.

http://docs.travis-ci.com/user/migrating-from-legacy/?utm_source=legacy-notice&utm_medium=banner&utm_campaign=legacy-upgrade